### PR TITLE
chore: bump commons-io:commons-io from 2.14.0 to 2.15.1

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -115,7 +115,7 @@
     <!-- do not update necessary for lesson -->
     <checkstyle.version>3.3.1</checkstyle.version>
     <commons-collections.version>3.2.1</commons-collections.version>
-    <commons-io.version>2.14.0</commons-io.version>
+    <commons-io.version>2.15.1</commons-io.version>
     <commons-lang3.version>3.12.0</commons-lang3.version>
     <commons-text.version>1.10.0</commons-text.version>
     <guava.version>32.1.3-jre</guava.version>


### PR DESCRIPTION
Bumps commons-io:commons-io from 2.14.0 to 2.15.1.

---
updated-dependencies:
- dependency-name: commons-io:commons-io dependency-type: direct:production update-type: version-update:semver-minor ...

Thank you for submitting a pull request to the WebGoat!
